### PR TITLE
Fixed repo deleted message

### DIFF
--- a/github-fixed-header.css
+++ b/github-fixed-header.css
@@ -12,6 +12,14 @@
   .discussion-sidebar.is-stuck {
     padding-top: 50px;
   }
+  
+  #js-flash-container + .main-content {
+    margin-top: 0px !important;
+  }
+
+  #js-flash-container {
+    padding-top: 50px;
+  }
 
   .header.header-logged-in {
     position: fixed;


### PR DESCRIPTION
Another PR ;P

This one fixes the "Repo deleted" message:

Without:
![captur2e](https://cloud.githubusercontent.com/assets/6440374/14031864/5face6c6-f1e5-11e5-9a71-26b57624f51b.PNG)

With:
![capture](https://cloud.githubusercontent.com/assets/6440374/14031868/64d69390-f1e5-11e5-8a50-ffc4ba1b08b7.PNG)

The rule applied to the main container is required, because the message would have pushed it down by 50px, so the rule brings the main container back to the right position.
